### PR TITLE
Fixed converting to pdf, when using online text / html

### DIFF
--- a/myproject/common/convert.py
+++ b/myproject/common/convert.py
@@ -6,7 +6,7 @@ import os
 import signal
 
 def convert_to(folder, source, timeout=None):
-    args = [libreoffice_exec(), '--headless', '--convert-to', 'pdf', '--outdir', folder, source]
+    args = [libreoffice_exec(), '--headless', '--writer', '--convert-to', 'pdf', '--outdir', folder, source]
 
     try:
         process = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, start_new_session=True)

--- a/version.txt
+++ b/version.txt
@@ -7,4 +7,4 @@
 # @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
 ##
 
-version = 2022032800;
+version = 2023062000;


### PR DESCRIPTION
Description:
When submitting an assignment, the first line in the online text would be removed for some odd reason, when a teacher is grading the assignments.
Skipping the first line (by hitting enter), and writing a new text works, but it also created a blank first page.
(The test instructions can be followed to show the error, before implementing the fix)

The fix makes sure that the online-text is shown as intended, when a teacher is grading the assignment.

Fix reference: https://stackoverflow.com/a/36888276


Test instructions:
1. Create a course (Course 1)
2. Enrol a teacher and a student to Course 1
3. Add an assignment, with the submission type; Online text
4. Create a submission as the student.
5. As the teacher, click the grade button
6. Verify that the online text is shown correctly, after the PDF is generated